### PR TITLE
Refactors for SDK 8.1.1, fixes off state timing bug

### DIFF
--- a/source/SinceStoppedApp.mc
+++ b/source/SinceStoppedApp.mc
@@ -17,8 +17,8 @@ class SinceStoppedApp extends Application.AppBase {
     }
 
     // Return the initial view of your application here
-    function getInitialView() as Array<Views or InputDelegates>? {
-        return [ new SinceStoppedView() ] as Array<Views or InputDelegates>;
+    function getInitialView() as [Views] or [Views, InputDelegates] {
+        return [ new SinceStoppedView() ];
     }
 
 }

--- a/source/SinceStoppedAppTests.mc
+++ b/source/SinceStoppedAppTests.mc
@@ -295,7 +295,7 @@ function testMoveStopTimerPause(logger as Logger) as Boolean {
   return (false);
 }
 
-// Tests that the counter doesn't start reading until we have started the timer
+// Tests that the counter doesn't start reading until we have started the device timer
 (:test)
 function testTimerOffOnMove(logger as Logger) as Boolean {
   
@@ -308,7 +308,7 @@ function testTimerOffOnMove(logger as Logger) as Boolean {
   var secondDuration = new Time.Duration(1);
   var response = "";
 
-  // Generate 5 mins of speed readings
+  // Generate 5 mins of speed readings, with timer off
   for (var i = 0; i < 300; i++) {
     response = testView.getDisplayText(testActivity, testTime);
     testTime = testTime.add(secondDuration);
@@ -319,7 +319,7 @@ function testTimerOffOnMove(logger as Logger) as Boolean {
     logger.debug("after 5 mins moving response was [" + response + "]");
     return false;
   }
-
+  
   // Timer on and do 2 mins of speed readings, counter should show 2 mins not 7 mins
   testActivity.timerState = Activity.TIMER_STATE_ON;
   testActivity.currentSpeed = 0.5;

--- a/source/SinceStoppedView.mc
+++ b/source/SinceStoppedView.mc
@@ -38,9 +38,9 @@ class SinceStoppedView extends WatchUi.SimpleDataField {
 
     function getDisplayText(info as Activity.Info, timeNow as Time.Moment) as String {
 
-        // timer is off so we are not in an activity, therefore re-init moving start time.
+        // timer is in off state so we are not in an activity, therefore re-init moving start time.
         if (info.timerState == Activity.TIMER_STATE_OFF) {
-            self._currentMovingStartedTime = Time.now();
+            self._currentMovingStartedTime = timeNow;
             self._lastMovingTime = self._currentMovingStartedTime;
             return "00:00";
         }
@@ -73,6 +73,7 @@ class SinceStoppedView extends WatchUi.SimpleDataField {
         // this means we do not update _lastMovingTime if device timer paused/stopped.
         if (currentSpeed > 0 && self._jitterDetector == 0 && info.timerState == Activity.TIMER_STATE_ON) {
             // update _lastMovingTime if we are currently moving.
+            
             //System.println("compute(): currently moving at speed " + info.currentSpeed);
 			self._lastMovingTime = timeNow;
 		} else {


### PR DESCRIPTION
```
==============================================================================
RESULTS
Test:                               Status:
testAlwaysStationaryTimerOn         PASS
testAlwaysMovingTimerOn             PASS
testMoveStopTimerOn                 PASS
testMoveStopJitterTimerOn           PASS
testMoveStopMoveTimerOn             PASS
testMoveStopTimerPause              PASS
testTimerOffOnMove                  PASS
testMovePauseOverThreshold          PASS
testAlwaysStationaryTimerOn         PASS
testAlwaysMovingTimerOn             PASS
testMoveStopTimerOn                 PASS
testMoveStopJitterTimerOn           PASS
testMoveStopMoveTimerOn             PASS
testMoveStopTimerPause              PASS
testTimerOffOnMove                  PASS
testMovePauseOverThreshold          PASS
testAlwaysStationaryTimerOn         PASS
testAlwaysMovingTimerOn             PASS
testMoveStopTimerOn                 PASS
testMoveStopJitterTimerOn           PASS
testMoveStopMoveTimerOn             PASS
testMoveStopTimerPause              PASS
testTimerOffOnMove                  PASS
testMovePauseOverThreshold          PASS
Ran 24 tests

PASSED (passed=24, failed=0, errors=0)
```